### PR TITLE
Move Integer to Long to avoind erroring out on hosts with large mem

### DIFF
--- a/jlxd-core/src/main/java/au/com/jcloud/lxd/model/State.java
+++ b/jlxd-core/src/main/java/au/com/jcloud/lxd/model/State.java
@@ -50,8 +50,8 @@ public class State {
 	@SerializedName("status_code")
 	private int statusCode;
 	private Map<String, Map<String, String>> disk;
-	private Map<String, Integer> memory;
-	private Map<MemoryEnum, Integer> memoryData = new HashMap<MemoryEnum, Integer>();
+	private Map<String, Long> memory;
+	private Map<MemoryEnum, Long> memoryData = new HashMap<MemoryEnum, Long>();
 	private Map<String, NetworkInterface> network;
 	int pid;
 	int processes;
@@ -95,11 +95,11 @@ public class State {
 	
 	public String getMemoryInMB(MemoryEnum type) {
 		getMemoryData();
-		Integer memoryValue = memoryData.get(type);
+		Long memoryValue = memoryData.get(type);
 		return (memoryValue!=null) ? FormatUtils.convertIntegerToMB(memoryValue) : "0";
 	}
 	
-	public Map<MemoryEnum, Integer> getMemoryData() {
+	public Map<MemoryEnum, Long> getMemoryData() {
 		if (!memoryData.isEmpty()) {
 			return memoryData;
 		}
@@ -146,11 +146,11 @@ public class State {
 		this.disk = disk;
 	}
 
-	public Map<String, Integer> getMemory() {
+	public Map<String, Long> getMemory() {
 		return memory;
 	}
 
-	public void setMemory(Map<String, Integer> memory) {
+	public void setMemory(Map<String, Long> memory) {
 		this.memory = memory;
 	}
 

--- a/jlxd-core/src/main/java/au/com/jcloud/lxd/util/FormatUtils.java
+++ b/jlxd-core/src/main/java/au/com/jcloud/lxd/util/FormatUtils.java
@@ -25,11 +25,11 @@ public class FormatUtils {
 		return DATE_FORMAT_ISO8601_SHORT_EXT.format(date);
 	}
 
-	public static String convertIntegerToMB(Integer input) {
+	public static String convertIntegerToMB(Long input) {
 		return String.valueOf(new BigDecimal(Double.valueOf(input) / 1024 / 1024).setScale(2, RoundingMode.HALF_UP));
 	}
 	
-	public static String convertIntegerToKB(Integer input) {
+	public static String convertIntegerToKB(Long input) {
 		return String.valueOf(new BigDecimal(Double.valueOf(input) / 1024).setScale(2, RoundingMode.HALF_UP));
 	}
 

--- a/jlxd-core/src/test/java/au/com/jcloud/lxd/util/FormatUtilsTest.java
+++ b/jlxd-core/src/test/java/au/com/jcloud/lxd/util/FormatUtilsTest.java
@@ -11,48 +11,48 @@ public class FormatUtilsTest {
 
 	@Test
 	public void convertIntegerToMB_shouldHandle0() {
-		assertEquals("0.00",FormatUtils.convertIntegerToMB(0));
+		assertEquals("0.00",FormatUtils.convertIntegerToMB(0L));
 	}
 	
 	@Test
 	public void convertIntegerToMB_shouldHandleSmallIntegers() {
-		assertEquals("0.00",FormatUtils.convertIntegerToMB(1024));
-		assertEquals("0.98",FormatUtils.convertIntegerToMB(1024000));
+		assertEquals("0.00",FormatUtils.convertIntegerToMB(1024L));
+		assertEquals("0.98",FormatUtils.convertIntegerToMB(1024000L));
 	}
 	
 	@Test
 	public void convertIntegerToMB_shouldHandleLargeInteger() {
-		assertEquals("8.78",FormatUtils.convertIntegerToMB(9207808));
-		assertEquals("9.11",FormatUtils.convertIntegerToMB(9555968));
+		assertEquals("8.78",FormatUtils.convertIntegerToMB(9207808L));
+		assertEquals("9.11",FormatUtils.convertIntegerToMB(9555968L));
 	}
 	
 	@Test
 	public void convertIntegerToMB_shouldHandleRoundUp() {
-		assertEquals("0.00",FormatUtils.convertIntegerToMB(5*1024));
-		assertEquals("0.01",FormatUtils.convertIntegerToMB(6*1024));
+		assertEquals("0.00",FormatUtils.convertIntegerToMB(5*1024L));
+		assertEquals("0.01",FormatUtils.convertIntegerToMB(6*1024L));
 	}
 	
 	@Test
 	public void convertIntegerToKB_shouldHandle0() {
-		assertEquals("0.00",FormatUtils.convertIntegerToKB(0));
+		assertEquals("0.00",FormatUtils.convertIntegerToKB(0L));
 	}
 	
 	@Test
 	public void convertIntegerToKB_shouldHandleSmallIntegers() {
-		assertEquals("0.25",FormatUtils.convertIntegerToKB(256));
-		assertEquals("0.50",FormatUtils.convertIntegerToKB(513));
+		assertEquals("0.25",FormatUtils.convertIntegerToKB(256L));
+		assertEquals("0.50",FormatUtils.convertIntegerToKB(513L));
 	}
 	
 	@Test
 	public void convertIntegerToKB_shouldHandleLargeInteger() {
-		assertEquals("90.63",FormatUtils.convertIntegerToKB(92808));
-		assertEquals("9332.00",FormatUtils.convertIntegerToKB(9555968));
+		assertEquals("90.63",FormatUtils.convertIntegerToKB(92808L));
+		assertEquals("9332.00",FormatUtils.convertIntegerToKB(9555968L));
 	}
 	
 	@Test
 	public void convertIntegerToKB_shouldHandleRoundUp() {
-		assertEquals("0.00",FormatUtils.convertIntegerToKB(5));
-		assertEquals("0.01",FormatUtils.convertIntegerToKB(6));
+		assertEquals("0.00",FormatUtils.convertIntegerToKB(5L));
+		assertEquals("0.01",FormatUtils.convertIntegerToKB(6L));
 	}
 	
 	@Test


### PR DESCRIPTION
While playing with jlxd-ui i noticed that if the host has a bit too much memory (32GB for example). an exception would be emited when trying to list the containers on a host. This boils down to `Integer` being too small to handle the amount of ram.

This pull fixes this by moving it to `Long`. Probably it would be even better to move it to double but that is left at the discretion of the maintainer.